### PR TITLE
Added a preference to hide seconds from menubar

### DIFF
--- a/Pomodoro/English.lproj/MainMenu.xib
+++ b/Pomodoro/English.lproj/MainMenu.xib
@@ -2784,6 +2784,26 @@ DQ
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="OQr-oD-XN8">
+                                            <rect key="frame" x="151" y="340" width="147" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Seconds on status bar:" id="sa6-3S-c0d">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <button id="5EK-nc-CM2">
+                                            <rect key="frame" x="302" y="339" width="243" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Show" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="xEf-xn-xB8">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="36" name="value" keyPath="values.showTimeWithSeconds" id="ggS-0X-xgQ"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/Pomodoro/German.lproj/MainMenu.xib
+++ b/Pomodoro/German.lproj/MainMenu.xib
@@ -2423,6 +2423,26 @@ DQ
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <button id="8BD-b3-og1">
+                                            <rect key="frame" x="302" y="340" width="243" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Anzeigen" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="TDr-li-BbJ">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="36" name="value" keyPath="values.showTimeWithSeconds" id="1da-6F-RO6"/>
+                                            </connections>
+                                        </button>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="IT9-Xc-sdZ">
+                                            <rect key="frame" x="110" y="339" width="189" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sekunden in der Menü-Leiste:" id="32U-MN-mvG">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/Pomodoro/src/PomodoroController.m
+++ b/Pomodoro/src/PomodoroController.m
@@ -45,11 +45,15 @@
 #pragma mark ---- Helper methods ----
 
 - (void) showTimeOnStatusBar:(NSInteger) time {	
-	if ([self checkDefault:@"showTimeOnStatusEnabled"]) {
-		[statusItem setTitle:[NSString stringWithFormat:@" %.2ld:%.2ld",time/60, time%60]];
-	} else {
-		[statusItem setTitle:@""];
-	}
+    if ([self checkDefault:@"showTimeOnStatusEnabled"]) {
+        if ([self checkDefault:@"showTimeWithSeconds"]) {
+            [statusItem setTitle:[NSString stringWithFormat:@" %.2ld:%.2ld",time/60, time%60]];
+         } else {
+            [statusItem setTitle:[NSString stringWithFormat:@" %.2ld",time/60]];
+        }
+    } else {
+        [statusItem setTitle:@""];
+    }
 }
 
 - (void) longBreakCheckerFinished {
@@ -78,7 +82,9 @@
                        context:(void *)context {
     	
 	if ([keyPath isEqualToString:@"showTimeOnStatusEnabled"]) {		
-		[self showTimeOnStatusBar: _initialTime * 60];		
+		[self showTimeOnStatusBar: _initialTime * 60];
+	} else if ([keyPath isEqualToString:@"showTimeWithSeconds"]) {
+		[self showTimeOnStatusBar: _initialTime * 60];
 	} else if ([keyPath isEqualToString:@"initialTime"]) {
         NSInteger duration = [[change objectForKey:NSKeyValueChangeNewKey] intValue];
         [pomodoro setDurationMinutes:duration];
@@ -588,11 +594,15 @@
 	[self observeUserDefault:@"initialTime"];
 	
 	[self observeUserDefault:@"showTimeOnStatusEnabled"];
+	[self observeUserDefault:@"showTimeWithSeconds"];
 	
 	if ([self checkDefault:@"showSplashScreenAtStartup"]) {
 		[self help:nil];
 	}
     
+	// show again time to handle showTimeWithSeconds
+	[self showTimeOnStatusBar: _initialTime * 60];
+
     [self updateMenu];
 		
 }

--- a/Pomodoro/src/PomodoroDefaults.m
+++ b/Pomodoro/src/PomodoroDefaults.m
@@ -150,6 +150,7 @@
 	[defaultValues setObject:[NSNumber numberWithInt:20] forKey:@"tickVolume"];
 	
 	[defaultValues setObject:[NSNumber numberWithBool:YES] forKey:@"showTimeOnStatusEnabled"];
+	[defaultValues setObject:[NSNumber numberWithBool:YES] forKey:@"showTimeWithSeconds"];
 	
 	[defaultValues setObject:[NSNumber numberWithBool:NO] forKey:@"calendarEnabled"];
 	[defaultValues setObject:@"Timers" forKey:@"selectedCalendar"];
@@ -305,6 +306,7 @@
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"voiceVolume"];
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"tickVolume"];
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"showTimeOnStatusEnabled"];
+	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"showTimeWithSeconds"];
 	
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"calendarEnabled"];
 	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"selectedCalendar"];


### PR DESCRIPTION
This patch adds an option to switch seconds on/off at the menubar. It solves an issue #22 . Could you please review it and possibly merge? Thank you!